### PR TITLE
Add `ENABLE` register 

### DIFF
--- a/axistream_in/hardware/src/iob_axistream_in.v
+++ b/axistream_in/hardware/src/iob_axistream_in.v
@@ -128,7 +128,8 @@ module iob_axistream_in # (
      .level_o          ()
      );
   
-  assign tready_o = ~fifo_full & !received_tlast;  //Only ready for more data when fifo not full and CPU read AXISTREAMIN_LAST data
+  //Only ready for more data when fifo not full, CPU has read AXISTREAMIN_LAST data, and `ENABLE` register is active
+  assign tready_o = ~fifo_full & !received_tlast & ENABLE;
 
   //Convert ext_mem_w_en signal to byte enable signal
   localparam num_bytes_per_input = TDATA_W/8;

--- a/axistream_in/iob_axistream_in_setup.py
+++ b/axistream_in/iob_axistream_in_setup.py
@@ -52,6 +52,7 @@ regs = \
         {'name':"EMPTY", 'type':"R", 'n_bits':1, 'rst_val':0, 'addr':4, 'log2n_items':0, 'autologic':False, 'descr':"1 bit: Return if FIFO is empty (May be empty due to waiting for more data or because it received a TLAST signal)"},
         {'name':"LAST", 'type':"R", 'n_bits':5, 'rst_val':0, 'addr':8, 'log2n_items':0, 'autologic':False, 'descr':"1+4 bits: [Bit 4] Signals if FIFO is empty due to receiving a TLAST signal; [Bit 3-0] Tells which bytes (from latest value of AXISTREAMIN_OUT) are valid (similar to WSTRB signal of AXI Stream). (Reading from this register makes it reset and starts filling FIFO with next frame)"},
         {'name':"SOFTRESET", 'type':"W", 'n_bits':1, 'rst_val':0, 'addr':12, 'log2n_items':0, 'autologic':True, 'descr':"Soft reset."},
+        {'name':"ENABLE", 'type':"W", 'n_bits':1, 'rst_val':1, 'addr':13, 'log2n_items':0, 'autologic':True, 'descr':"Enable peripheral."},
 
     ]}
 ]

--- a/axistream_in/software/src/iob-axistream-in.c
+++ b/axistream_in/software/src/iob-axistream-in.c
@@ -61,3 +61,13 @@ void axistream_in_reset(){
   IOB_AXISTREAM_IN_SET_SOFTRESET(1);
   IOB_AXISTREAM_IN_SET_SOFTRESET(0);
 }
+
+//Enable peripheral
+void axistream_in_enable(){
+  IOB_AXISTREAM_IN_SET_ENABLE(1);
+}
+
+//Disable tready signal, preventing new transfers
+void axistream_in_disable(){
+  IOB_AXISTREAM_IN_SET_ENABLE(0);
+}

--- a/axistream_in/software/src/iob-axistream-in.h
+++ b/axistream_in/software/src/iob-axistream-in.h
@@ -19,3 +19,6 @@ bool axistream_in_was_last(char *rstrb);
 
 //Soft reset
 void axistream_in_reset();
+
+void axistream_in_enable();
+void axistream_in_disable();

--- a/axistream_out/iob_axistream_out_setup.py
+++ b/axistream_out/iob_axistream_out_setup.py
@@ -49,6 +49,7 @@ regs = \
         {'name':"IN", 'type':"W", 'n_bits':32, 'rst_val':0, 'addr':-1, 'log2n_items':0, 'autologic':False, 'descr':"32 bits: Set next FIFO input (Writing to this register pushes the value into the FIFO)"},
         {'name':"FULL", 'type':"R", 'n_bits':1, 'rst_val':0, 'addr':-1, 'log2n_items':0, 'autologic':True, 'descr':"1 bit: Return if FIFO is full"},
         {'name':"SOFTRESET", 'type':"W", 'n_bits':1, 'rst_val':0, 'addr':-1, 'log2n_items':0, 'autologic':True, 'descr':"Soft reset."},
+        {'name':"ENABLE", 'type':"W", 'n_bits':1, 'rst_val':1, 'addr':-1, 'log2n_items':0, 'autologic':True, 'descr':"Enable peripheral."},
         {'name':"WSTRB_NEXT_WORD_LAST", 'type':"W", 'n_bits':5, 'rst_val':0, 'addr':8, 'log2n_items':0, 'autologic':False, 'descr':"From 1 to 4 bits: Set which output words of the next input word in AXISTREAMOUT_IN are valid and send TLAST signal along with last valid byte. (If this register has value 0, all 4 bytes will be valid and it will not send a TLAST signal with the last byte [MSB]). When the output word width (TDATA) is 8, 16 or 32 bits, this register has size 4, 2 or 1 bits respectively."},
 
     ]}

--- a/axistream_out/software/src/iob-axistream-out.c
+++ b/axistream_out/software/src/iob-axistream-out.c
@@ -103,3 +103,13 @@ void axistream_out_reset(){
   IOB_AXISTREAM_OUT_SET_SOFTRESET(1);
   IOB_AXISTREAM_OUT_SET_SOFTRESET(0);
 }
+
+//Enable peripheral
+void axistream_out_enable(){
+  IOB_AXISTREAM_OUT_SET_ENABLE(1);
+}
+
+//Disable tready signal, preventing new transfers
+void axistream_out_disable(){
+  IOB_AXISTREAM_OUT_SET_ENABLE(0);
+}

--- a/axistream_out/software/src/iob-axistream-out.h
+++ b/axistream_out/software/src/iob-axistream-out.h
@@ -20,3 +20,6 @@ void axistream_out_free();
 
 //Soft reset
 void axistream_out_reset();
+
+void axistream_out_enable();
+void axistream_out_disable();


### PR DESCRIPTION
Add `ENABLE` register and drivers to control it. This register allows enabling (default state) and disabling the `axistream_in` and `axistream_out` peripherals.
When disabled, the `axistream_in` will not receive new values by keeping the `tready_o` signal low.
When disabled, the `axistream_out` will not send new values from the FIFO.