### PR TITLE
fix(rvalid): remove unused rvalid signal

### DIFF
--- a/axistream_in/hardware/src/iob_axistream_in.v
+++ b/axistream_in/hardware/src/iob_axistream_in.v
@@ -138,17 +138,6 @@ module iob_axistream_in #(
    wire wren_int;
    assign wren_int = ((axis_tvalid_i & ready_int) | (state == STATE_PADDING)) & axis_sw_enable;
 
-   iob_reg_re #(
-      .DATA_W (1),
-      .RST_VAL(1'd0)
-   ) reg_DATA_valid (
-      `include "clk_en_rst_s_s_portmap.vs"
-      .rst_i (SOFT_RESET_wr),
-      .en_i  (ENABLE_wr),
-      .data_i(read_fifos),
-      .data_o(DATA_rvalid_rd)
-   );
-
    iob_fifo_async #(
       .W_DATA_W(TDATA_W),
       .R_DATA_W(32),


### PR DESCRIPTION
- previous rvalid removal must have been reverted in a merge conflict resolution